### PR TITLE
fix: align vercel routing config

### DIFF
--- a/docs/UPDATE/2025-10-05-fix-vercel-mix-routing.md
+++ b/docs/UPDATE/2025-10-05-fix-vercel-mix-routing.md
@@ -1,0 +1,2 @@
+- fix(vercel): remove vercel.json routes to avoid mix of routing props
+- keep routing only in next.config.js (rewrites/redirects for /demo)

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,35 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/demo',
+        destination: '/demo/',
+        permanent: true,
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/demo/:path*',
+        destination: '/demo/:path*',
+      },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: '/demo/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,1 @@
-{
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
-}
+{ "version": 2 }


### PR DESCRIPTION
## Summary
- strip custom routes from vercel.json to rely on Next.js configuration
- add Next.js redirects, rewrites, and headers for the /demo path
- document the routing change for deployment history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e291bd8c94832e9553f67d6d6f0d7c