### PR TITLE
feat(demo): add API switch for drivers data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+
+## Demo data source
+
+- Toggle in `src/environments/*`: `demoUseApi` (false → LocalStorage + mock API; true → DriversApiService → реальный бэк).
+- API contract (по умолчанию):
+  - `GET ${demoApiBase}/drivers` → `Driver[]`
+  - `PUT ${demoApiBase}/drivers` → bulk replace (void)
+  - `POST ${demoApiBase}/drivers` → create (returns `Driver`)
+  - `PUT ${demoApiBase}/drivers/:id` → update (returns `Driver`)
+  - `DELETE ${demoApiBase}/drivers` body `{ids: string[]}` → bulk delete (void)
+- `demoApiBase` можно перенаправить на прокси/домен бэка.

--- a/docs/UPDATE/2025-10-05-demo-data-source-switch.md
+++ b/docs/UPDATE/2025-10-05-demo-data-source-switch.md
@@ -1,0 +1,3 @@
+- feat(demo): data source switch for Drivers — API adapter + env toggle + mock interceptor
+- env: demoUseApi=false|true, demoApiBase="/api"
+- when demoUseApi=false → DemoApiInterceptor эмулирует /api/drivers на базе LocalStorage

--- a/src/app/demo/demo.routes.ts
+++ b/src/app/demo/demo.routes.ts
@@ -1,0 +1,32 @@
+import { Type } from '@angular/core';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { Routes } from '@angular/router';
+
+import { environment } from '../../environments/environment';
+import { DRIVERS_DATA } from './shared/data.port';
+import { DriversApiService } from './features/drivers/drivers.data.api';
+import { LocalDriversDataService } from './features/drivers/drivers.data.local';
+import { DemoApiInterceptor } from './shared/demo-api.interceptor';
+
+const shellComponentPlaceholder = null as unknown as Type<unknown>;
+
+const shouldUseApi = (environment as { demoUseApi?: boolean }).demoUseApi ?? false;
+
+export const DEMO_ROUTES: Routes = [
+  {
+    path: '',
+    component: shellComponentPlaceholder,
+    providers: [
+      provideHttpClient(
+        ...(shouldUseApi ? [] : [withInterceptors([() => new DemoApiInterceptor()])]),
+      ),
+      {
+        provide: DRIVERS_DATA,
+        useFactory: (api: DriversApiService, local: LocalDriversDataService) =>
+          ((environment as { demoUseApi?: boolean }).demoUseApi ?? false) ? api : local,
+        deps: [DriversApiService, LocalDriversDataService],
+      },
+    ],
+    children: [],
+  },
+];

--- a/src/app/demo/features/drivers/drivers.data.api.ts
+++ b/src/app/demo/features/drivers/drivers.data.api.ts
@@ -1,0 +1,41 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+import { Driver, DriversDataPort } from '../../shared/data.port';
+import { environment } from '../../../../environments/environment';
+
+const normalizeBase = (base: string | undefined) => {
+  if (!base) {
+    return '/api';
+  }
+  return base.endsWith('/') ? base.slice(0, -1) : base;
+};
+
+@Injectable({ providedIn: 'root' })
+export class DriversApiService implements DriversDataPort {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = `${normalizeBase(environment.demoApiBase)}/drivers`;
+
+  load(): Promise<Driver[]> {
+    return firstValueFrom(this.http.get<Driver[]>(this.baseUrl));
+  }
+
+  save(list: Driver[]): Promise<void> {
+    return firstValueFrom(this.http.put<void>(this.baseUrl, list));
+  }
+
+  add(driver: Driver): Promise<Driver> {
+    return firstValueFrom(this.http.post<Driver>(this.baseUrl, driver));
+  }
+
+  update(id: string, patch: Partial<Driver>): Promise<Driver> {
+    return firstValueFrom(this.http.put<Driver>(`${this.baseUrl}/${id}`, patch));
+  }
+
+  removeMany(ids: string[]): Promise<void> {
+    return firstValueFrom(
+      this.http.request<void>('DELETE', this.baseUrl, { body: { ids } }),
+    );
+  }
+}

--- a/src/app/demo/features/drivers/drivers.data.local.ts
+++ b/src/app/demo/features/drivers/drivers.data.local.ts
@@ -1,0 +1,257 @@
+import { Injectable } from '@angular/core';
+import { Driver, DriversDataPort } from '../../shared/data.port';
+
+export const DRIVERS_STORAGE_KEY = 'gtrack_demo_drivers_v4';
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `drv_${Math.random().toString(16).slice(2)}_${Date.now()}`;
+};
+
+const futureDate = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString().split('T')[0];
+};
+
+const pastDate = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString().split('T')[0];
+};
+
+const DRIVER_SEED_BASE: Omit<Driver, 'id'>[] = [
+  {
+    fullName: 'Marek Král',
+    rc: '820312/2145',
+    email: 'marek.kral@example.cz',
+    phone: '+420 737 244 889',
+    status: 'Active',
+    citizenship: 'CZ',
+    workplace: 'Praha',
+    hireDate: '2022-03-11',
+    contractType: 'HPP',
+    pasSouhlas: true,
+    propiskaCZ: true,
+    docs: {
+      passport: { expires: futureDate(300), uploaded: true },
+      visa: { expires: futureDate(90), uploaded: true },
+      license: { expires: futureDate(120), uploaded: true },
+      code95: { expires: futureDate(220), uploaded: true },
+      tachograph: { expires: futureDate(60), uploaded: true },
+      medical: { expires: futureDate(160), uploaded: true },
+      adr: { expires: futureDate(200), uploaded: true },
+    },
+    salary: { base: 32000, bonus: 2800, deductions: 1100, trips: 6, perDiem: 900 },
+  },
+  {
+    fullName: 'Elena Novotná',
+    rc: '950215/8811',
+    email: 'elena.novotna@example.cz',
+    phone: '+420 734 123 789',
+    status: 'Active',
+    citizenship: 'EU',
+    workplace: 'Praha',
+    hireDate: '2023-02-14',
+    contractType: 'Срочный',
+    pasSouhlas: false,
+    propiskaCZ: true,
+    docs: {
+      passport: { expires: futureDate(400), uploaded: true },
+      visa: { expires: futureDate(250), uploaded: true },
+      license: { expires: futureDate(75), uploaded: true },
+      code95: { expires: futureDate(180), uploaded: true },
+      tachograph: { expires: futureDate(90), uploaded: true },
+      medical: { expires: futureDate(45), uploaded: true },
+      adr: { expires: futureDate(160), uploaded: true },
+    },
+    salary: { base: 27000, bonus: 3000, deductions: 900, trips: 5, perDiem: 850 },
+  },
+  {
+    fullName: 'Igor Shevchenko',
+    rc: '870621/4412',
+    email: 'igor.shevchenko@example.cz',
+    phone: '+420 602 655 188',
+    status: 'On leave',
+    citizenship: 'UA',
+    workplace: 'Brno',
+    hireDate: '2021-11-02',
+    contractType: 'HPP',
+    pasSouhlas: true,
+    propiskaCZ: false,
+    docs: {
+      passport: { expires: futureDate(90), uploaded: true },
+      visa: { expires: pastDate(15), uploaded: true },
+      license: { expires: futureDate(30), uploaded: true },
+      code95: { expires: futureDate(12), uploaded: true },
+      tachograph: { expires: pastDate(2), uploaded: false },
+      medical: { expires: futureDate(200), uploaded: true },
+      adr: { expires: futureDate(60), uploaded: true },
+    },
+    salary: { base: 24000, bonus: 1800, deductions: 800, trips: 3, perDiem: 780 },
+  },
+  {
+    fullName: 'Karolina Veselá',
+    rc: '930902/0084',
+    email: 'karolina.vesela@example.cz',
+    phone: '+420 773 491 028',
+    status: 'Active',
+    citizenship: 'CZ',
+    workplace: 'Ostrava',
+    hireDate: '2020-08-20',
+    contractType: 'HPP',
+    pasSouhlas: true,
+    propiskaCZ: true,
+    docs: {
+      passport: { expires: futureDate(650), uploaded: true },
+      visa: { expires: futureDate(280), uploaded: true },
+      license: { expires: futureDate(45), uploaded: true },
+      code95: { expires: futureDate(60), uploaded: true },
+      tachograph: { expires: futureDate(30), uploaded: true },
+      medical: { expires: futureDate(15), uploaded: true },
+      adr: { expires: futureDate(330), uploaded: true },
+    },
+    salary: { base: 29500, bonus: 2400, deductions: 650, trips: 8, perDiem: 920 },
+  },
+  {
+    fullName: 'Tomas Černý',
+    rc: '900125/5110',
+    email: 'tomas.cerny@example.cz',
+    phone: '+420 728 490 321',
+    status: 'Active',
+    citizenship: 'CZ',
+    workplace: 'Plzeň',
+    hireDate: '2019-05-01',
+    contractType: 'HPP',
+    pasSouhlas: true,
+    propiskaCZ: true,
+    docs: {
+      passport: { expires: futureDate(140), uploaded: true },
+      visa: { expires: futureDate(140), uploaded: true },
+      license: { expires: pastDate(10), uploaded: true },
+      code95: { expires: futureDate(22), uploaded: true },
+      tachograph: { expires: pastDate(30), uploaded: false },
+      medical: { expires: futureDate(75), uploaded: true },
+      adr: { expires: futureDate(190), uploaded: true },
+    },
+    salary: { base: 31000, bonus: 2100, deductions: 1000, trips: 4, perDiem: 840 },
+  },
+];
+
+const createSeed = (): Driver[] => DRIVER_SEED_BASE.map((item) => ({ ...item, id: createId() }));
+
+const getStorage = (): Storage | undefined => {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+};
+
+export const readDriversFromStorage = (): Driver[] => {
+  const storage = getStorage();
+  if (!storage) {
+    return createSeed();
+  }
+  try {
+    const raw = storage.getItem(DRIVERS_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as Driver[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const writeDriversToStorage = (list: Driver[]): void => {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(DRIVERS_STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // ignore write errors in demo mode
+  }
+};
+
+export const ensureDriversSeed = (): Driver[] => {
+  const existing = readDriversFromStorage();
+  if (existing.length > 0) {
+    return existing;
+  }
+  const seeded = createSeed();
+  writeDriversToStorage(seeded);
+  return seeded;
+};
+
+const mergeDocs = (original: Driver['docs'], patch?: Partial<Driver['docs']>) => {
+  if (!patch) {
+    return original;
+  }
+  return { ...original, ...patch };
+};
+
+const mergeSalary = (original: Driver['salary'], patch?: Partial<Driver['salary']>) => {
+  if (!patch) {
+    return original;
+  }
+  return { ...original, ...patch };
+};
+
+@Injectable({ providedIn: 'root' })
+export class LocalDriversDataService implements DriversDataPort {
+  async load(): Promise<Driver[]> {
+    return [...ensureDriversSeed()];
+  }
+
+  async save(list: Driver[]): Promise<void> {
+    writeDriversToStorage(list);
+  }
+
+  async add(driver: Driver): Promise<Driver> {
+    const list = ensureDriversSeed();
+    const record: Driver = { ...driver, id: driver.id || createId() };
+    writeDriversToStorage([record, ...list]);
+    return record;
+  }
+
+  async update(id: string, patch: Partial<Driver>): Promise<Driver> {
+    const list = ensureDriversSeed();
+    let next: Driver | undefined;
+    const updated = list.map((item) => {
+      if (item.id !== id) {
+        return item;
+      }
+      next = {
+        ...item,
+        ...patch,
+        docs: mergeDocs(item.docs, patch.docs),
+        salary: mergeSalary(item.salary, patch.salary),
+      };
+      return next;
+    });
+    if (!next) {
+      throw new Error(`Driver with id ${id} not found`);
+    }
+    writeDriversToStorage(updated);
+    return next;
+  }
+
+  async removeMany(ids: string[]): Promise<void> {
+    if (!ids.length) {
+      return;
+    }
+    const set = new Set(ids);
+    const list = ensureDriversSeed();
+    const filtered = list.filter((item) => !set.has(item.id));
+    writeDriversToStorage(filtered);
+  }
+}

--- a/src/app/demo/shared/data.port.ts
+++ b/src/app/demo/shared/data.port.ts
@@ -1,0 +1,43 @@
+import { InjectionToken } from '@angular/core';
+
+export type DriverDocumentState = {
+  expires: string | null;
+  uploaded: boolean;
+};
+
+export type DriverDocuments = Record<string, DriverDocumentState>;
+
+export type DriverSalary = {
+  base: number;
+  bonus: number;
+  deductions: number;
+  trips: number;
+  perDiem: number;
+};
+
+export type Driver = {
+  id: string;
+  fullName: string;
+  rc: string;
+  email: string;
+  phone: string;
+  status: string;
+  citizenship: string;
+  workplace: string;
+  hireDate: string | null;
+  contractType: string;
+  pasSouhlas: boolean;
+  propiskaCZ: boolean;
+  docs: DriverDocuments;
+  salary: DriverSalary;
+};
+
+export interface DriversDataPort {
+  load(): Promise<Driver[]>;
+  save(list: Driver[]): Promise<void>;
+  add?(driver: Driver): Promise<Driver>;
+  update?(id: string, patch: Partial<Driver>): Promise<Driver>;
+  removeMany?(ids: string[]): Promise<void>;
+}
+
+export const DRIVERS_DATA = new InjectionToken<DriversDataPort>('DRIVERS_DATA');

--- a/src/app/demo/shared/demo-api.interceptor.ts
+++ b/src/app/demo/shared/demo-api.interceptor.ts
@@ -1,0 +1,183 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+import { Driver } from './data.port';
+import {
+  ensureDriversSeed,
+  readDriversFromStorage,
+  writeDriversToStorage,
+} from '../features/drivers/drivers.data.local';
+
+const normalizeBase = (base: string | undefined) => {
+  if (!base) {
+    return '/api';
+  }
+  const trimmed = base.trim();
+  if (!trimmed) {
+    return '/api';
+  }
+  const withSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return withSlash.endsWith('/') ? withSlash.slice(0, -1) : withSlash;
+};
+
+const stripOrigin = (url: string) => url.replace(/^https?:\/\/[^/]+/i, '');
+
+const extractPath = (url: string) => {
+  const withoutOrigin = stripOrigin(url);
+  const end = withoutOrigin.indexOf('?');
+  const hashIndex = withoutOrigin.indexOf('#');
+  const cutIndex = [end, hashIndex].filter((value) => value >= 0).sort((a, b) => a - b)[0];
+  return cutIndex >= 0 ? withoutOrigin.slice(0, cutIndex) : withoutOrigin;
+};
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `drv_${Math.random().toString(16).slice(2)}_${Date.now()}`;
+};
+
+const cloneDrivers = (drivers: Driver[]): Driver[] => drivers.map((item) => ({
+  ...item,
+  docs: { ...item.docs },
+  salary: { ...item.salary },
+}));
+
+const mergeDocs = (original: Driver['docs'], patch?: Partial<Driver['docs']>) => {
+  if (!patch) {
+    return original;
+  }
+  return { ...original, ...patch };
+};
+
+const mergeSalary = (original: Driver['salary'], patch?: Partial<Driver['salary']>) => {
+  if (!patch) {
+    return original;
+  }
+  return { ...original, ...patch };
+};
+
+@Injectable()
+export class DemoApiInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const useApi = (environment as { demoUseApi?: boolean }).demoUseApi ?? false;
+    if (useApi) {
+      return next.handle(req);
+    }
+
+    const base = `${normalizeBase((environment as { demoApiBase?: string }).demoApiBase)}/drivers`;
+    const path = extractPath(req.url || req.urlWithParams);
+
+    if (!path.startsWith(base)) {
+      return next.handle(req);
+    }
+
+    const method = req.method.toUpperCase();
+    const current = ensureDriversSeed();
+    const getList = () => {
+      const stored = readDriversFromStorage();
+      if (!stored.length) {
+        writeDriversToStorage(current);
+        return cloneDrivers(current);
+      }
+      return cloneDrivers(stored);
+    };
+
+    if (method === 'GET' && path === base) {
+      return of(new HttpResponse({ status: 200, body: getList() }));
+    }
+
+    if (method === 'PUT' && path === base) {
+      const payload = Array.isArray(req.body) ? (req.body as Driver[]) : [];
+      writeDriversToStorage(cloneDrivers(payload));
+      return of(new HttpResponse({ status: 204 }));
+    }
+
+    if (method === 'POST' && path === base) {
+      const payload = (req.body || {}) as Partial<Driver>;
+      const driver: Driver = {
+        id: typeof payload.id === 'string' && payload.id ? payload.id : createId(),
+        fullName: payload.fullName ?? 'Unknown Driver',
+        rc: payload.rc ?? '',
+        email: payload.email ?? '',
+        phone: payload.phone ?? '',
+        status: payload.status ?? 'Active',
+        citizenship: payload.citizenship ?? '',
+        workplace: payload.workplace ?? '',
+        hireDate: payload.hireDate ?? null,
+        contractType: payload.contractType ?? 'HPP',
+        pasSouhlas: payload.pasSouhlas ?? false,
+        propiskaCZ: payload.propiskaCZ ?? false,
+        docs: { ...(payload.docs ?? {}) },
+        salary: {
+          base: payload.salary?.base ?? 0,
+          bonus: payload.salary?.bonus ?? 0,
+          deductions: payload.salary?.deductions ?? 0,
+          trips: payload.salary?.trips ?? 0,
+          perDiem: payload.salary?.perDiem ?? 0,
+        },
+      };
+      const nextList = [driver, ...getList()];
+      writeDriversToStorage(nextList);
+      return of(new HttpResponse({ status: 201, body: driver }));
+    }
+
+    const idMatch = path.match(/\/drivers\/([^/?#]+)/);
+    if (idMatch) {
+      const id = decodeURIComponent(idMatch[1]);
+
+      if (method === 'PUT' || method === 'PATCH') {
+        const payload = (req.body || {}) as Partial<Driver>;
+        const updatedList: Driver[] = [];
+        let updatedDriver: Driver | undefined;
+        for (const driver of getList()) {
+          if (driver.id === id) {
+            updatedDriver = {
+              ...driver,
+              ...payload,
+              docs: mergeDocs(driver.docs, payload.docs),
+              salary: mergeSalary(driver.salary, payload.salary),
+            };
+            updatedList.push(updatedDriver);
+          } else {
+            updatedList.push(driver);
+          }
+        }
+        if (!updatedDriver) {
+          return of(new HttpResponse({ status: 404 }));
+        }
+        writeDriversToStorage(updatedList);
+        return of(new HttpResponse({ status: 200, body: updatedDriver }));
+      }
+
+      if (method === 'DELETE') {
+        const list = getList().filter((driver) => driver.id !== id);
+        writeDriversToStorage(list);
+        return of(new HttpResponse({ status: 204 }));
+      }
+    }
+
+    if (method === 'DELETE' && path === base) {
+      const ids: string[] = Array.isArray((req.body as any)?.ids)
+        ? ((req.body as any).ids as string[])
+        : [];
+      if (!ids.length) {
+        return of(new HttpResponse({ status: 204 }));
+      }
+      const set = new Set(ids);
+      const list = getList().filter((driver) => !set.has(driver.id));
+      writeDriversToStorage(list);
+      return of(new HttpResponse({ status: 204 }));
+    }
+
+    return next.handle(req);
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,10 +1,21 @@
 import { Environment } from './environment.type';
 
+type DemoEnvironmentExtras = {
+  demoUseApi: boolean;
+  demoApiBase: string;
+};
+
 const apiBaseUrl = 'https://api.g-track.eu';
 
-export const environment: Environment = {
+const demoConfig: DemoEnvironmentExtras = {
+  demoUseApi: false,
+  demoApiBase: '/api',
+};
+
+export const environment: Environment & DemoEnvironmentExtras = {
   production: true,
   demoMode: true,
   apiBaseUrl,
   apiUrl: apiBaseUrl,
+  ...demoConfig,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,10 +1,21 @@
 import { Environment } from './environment.type';
 
+type DemoEnvironmentExtras = {
+  demoUseApi: boolean;
+  demoApiBase: string;
+};
+
 const apiBaseUrl = 'http://localhost:8000';
 
-export const environment: Environment = {
+const demoConfig: DemoEnvironmentExtras = {
+  demoUseApi: false,
+  demoApiBase: '/api',
+};
+
+export const environment: Environment & DemoEnvironmentExtras = {
   production: false,
   demoMode: true,
   apiBaseUrl,
   apiUrl: apiBaseUrl,
+  ...demoConfig,
 };


### PR DESCRIPTION
## Summary
- add environment switches so the demo can choose between local storage and an API endpoint
- introduce a Drivers data port with local and HTTP-backed implementations plus a mock interceptor
- wire the demo route providers and document the new configuration toggle

## Testing
- npm run build *(fails: existing `Echo<any>` type error in sse.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c7a677c0832eae636a4e3682ce74