### PR TITLE
fix: adjust Vercel install command and add lockfile sync workflow

### DIFF
--- a/.github/workflows/lockfile-sync.yml
+++ b/.github/workflows/lockfile-sync.yml
@@ -1,0 +1,35 @@
+name: Lockfile Sync
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+      - name: Use npm@10
+        run: npm i -g npm@10
+      - name: Regenerate lockfile only
+        run: |
+          rm -rf node_modules
+          npm install --package-lock-only
+      - name: Create PR with updated lockfile
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(lock): sync package-lock.json with package.json"
+          title: "chore(lock): sync package-lock.json"
+          body: "Auto-generated lockfile update after package.json changes."
+          branch: chore/lockfile-sync
+          add-paths: |
+            package-lock.json

--- a/docs/UPDATE/2025-10-05-lockfile-sync.md
+++ b/docs/UPDATE/2025-10-05-lockfile-sync.md
@@ -1,0 +1,3 @@
+- fix(vercel): use `npm install` during build to tolerate out-of-sync lockfile
+- ci: add lockfile-sync workflow to auto-create PR with updated package-lock.json
+- note: after merging the lockfile PR you may switch back to `npm ci` if desired

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,4 @@
-{ "version": 2 }
+{
+  "version": 2,
+  "installCommand": "npm install --no-audit --no-fund --loglevel=error"
+}


### PR DESCRIPTION
## Summary
- update Vercel installCommand to use npm install with quiet flags for resiliency
- add a lockfile sync workflow that regenerates package-lock.json and opens a PR
- document the workflow addition and build change in the update notes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2d2aa50f8832e8cef9ea7167df312