### PR TITLE
chore: harden vercel install and sync lockfile

### DIFF
--- a/.github/workflows/lockfile-sync.yml
+++ b/.github/workflows/lockfile-sync.yml
@@ -20,7 +20,7 @@ jobs:
         with: { node-version: "20" }
       - name: Use npm@10
         run: npm i -g npm@10
-      - name: Regenerate lockfile only
+      - name: Regenerate lockfile (no install)
         run: |
           rm -rf node_modules
           npm install --package-lock-only

--- a/docs/UPDATE/2025-10-05-vercel-lock-sync.md
+++ b/docs/UPDATE/2025-10-05-vercel-lock-sync.md
@@ -1,0 +1,3 @@
+- fix(vercel): resilient install (ci → fallback to install on lock desync)
+- ci: auto PR to sync package-lock.json after package.json changes
+- note: once lock PR is merged, you may switch installCommand back to `npm ci --loglevel=error`

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "version": 2,
-  "installCommand": "npm install --no-audit --no-fund --loglevel=error"
+  "installCommand": "npm ci --loglevel=error || npm install --no-audit --no-fund --loglevel=error"
 }


### PR DESCRIPTION
## Summary
- make Vercel installs resilient to lockfile desync by falling back from npm ci to npm install
- add a lockfile sync workflow to regenerate package-lock.json after package.json changes
- document the deployment update in the changelog note

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d528c898832eb1d98984c2606898