### PR TITLE
Add npm install fallback in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,14 +3,24 @@ on:
   pull_request:
   push:
     branches: [ "main" ]
-permissions: { contents: read }
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
+
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
-      - run: npm ci --loglevel=error
-      - run: npm run lint:ci
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install deps (ci with fallback)
+        run: |
+          npm ci --loglevel=error || (echo "::warning:: npm ci failed, falling back to npm install"; npm install --no-audit --no-fund --loglevel=error)
+
+      - name: Run lint
+        run: npm run lint:ci

--- a/docs/UPDATE/2025-10-05-ci-lint-fallback.md
+++ b/docs/UPDATE/2025-10-05-ci-lint-fallback.md
@@ -1,0 +1,2 @@
+- ci: make lint workflow resilient to lockfile desync (npm ci → fallback to npm install)
+- note: после авто-PR от Lockfile Sync можно вернуть строгий `npm ci`.


### PR DESCRIPTION
## Summary
- cache npm dependencies in lint workflow and add fallback install step
- document lint workflow resilience update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d6e8d8cc832e8b739f56501b25b6