### PR TITLE
fix: ensure demo interceptor merges driver docs safely

### DIFF
--- a/docs/UPDATE/2025-10-05-demo-interceptor-types-fix.md
+++ b/docs/UPDATE/2025-10-05-demo-interceptor-types-fix.md
@@ -1,0 +1,3 @@
+- fix(demo): correct docs merge to return full Record<DocKey, DriverDocumentState> (no undefined)
+- fix(demo): safe update in PUT /drivers/:id with index check and strict Driver type
+- result: Vercel build errors TS2322/TS2345 resolved


### PR DESCRIPTION
## Summary
- add a strictly typed mergeDriverDocs helper to keep demo driver documents fully defined during updates
- refactor the PUT/PATCH handler to guard against missing drivers and emit a concrete Driver response
- document the fix and resolved TS2322/TS2345 issues in the update log

## Testing
- CI=1 npm run build -- --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68e2e70e8428832e8ed9447728ffea34